### PR TITLE
Type system types as values syntax

### DIFF
--- a/OxAlc.Console/Examples/calculator.oxalc
+++ b/OxAlc.Console/Examples/calculator.oxalc
@@ -1,20 +1,17 @@
-let calculator := 
-    include [] for
-    type binary_op = number->number->number in 
-    type calc = { 
+let calculator := {
+    binary_op :type= number->number->number; 
+    calc :type= { 
         zero: number;
         one: number;
         add:binary_op; 
         sub:binary_op; 
         mul:binary_op; 
         div:binary_op; 
-    } in 
-    {
-        calc : calc = {
-            add:binary_op=(n: number, m:number) => m + n; 
-            sub:binary_op=(n: number, m:number) => m - n; 
-            mul:binary_op=(n: number, m:number) => m * n; 
-            div:binary_op=(n: number, m:number) => m / n;
-        }
-    }
-end calculator 
+    }; 
+    calc : calc = {
+        add:binary_op=(n: number, m:number) => m + n; 
+        sub:binary_op=(n: number, m:number) => m - n; 
+        mul:binary_op=(n: number, m:number) => m * n; 
+        div:binary_op=(n: number, m:number) => m / n;
+    };
+} end calculator 

--- a/OxAlc.Console/Examples/constants.oxalc
+++ b/OxAlc.Console/Examples/constants.oxalc
@@ -1,7 +1,6 @@
 let constants := {
-        zero  : number = 0;
-        one   : number = 1;
-        bool_t : bool = true;
-        bool_f : bool = false ;
-    }
-end constants 
+    zero  : number = 0;
+    one   : number = 1;
+    bool_t : bool = true;
+    bool_f : bool = false;
+} end constants 

--- a/OxAlc.Console/Examples/operators.oxalc
+++ b/OxAlc.Console/Examples/operators.oxalc
@@ -1,10 +1,10 @@
 let operators := 
     include [functions] for {
-        ++    := (n:number) => incr(n);
-        ??    := (b:bool, n:number, m:number) => cond(b, n, m);
-        ==    := (n:number, m:number) => ((n = m) ?? 1)(0);
-        <>    := (n:number, m:number) => ((n = m) ?? 0)(1);
-        ?    := (n:number) => if n = 0 then false else true;
-        |>    := (m:number, f:number->number) => f(m);
+        ++  := (n:number) => incr(n);
+        ??  := (b:bool, n:number, m:number) => cond(b, n, m);
+        ==  := (n:number, m:number) => ((n = m) ?? 1)(0);
+        <>  := (n:number, m:number) => ((n = m) ?? 0)(1);
+        ?   := (n:number) => if n = 0 then false else true;
+        |>  := (m:number, f:number->number) => f(m);
     }
 end operators

--- a/OxAlc.Console/Properties/launchSettings.json
+++ b/OxAlc.Console/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "OxAlc.Console": {
       "commandName": "Project",
-      "commandLineArgs": "--mode Terminal --back JS"
+      "commandLineArgs": "--mode \"C:\\Users\\Ayman\\source\\repos\\Lambda-Calculus\\OxAlc.Console\\bin\\Debug\\net6.0\\programs1.oxalc\" --back JS"
     }
   }
 }

--- a/OxAlc.Service/Compiler.fs
+++ b/OxAlc.Service/Compiler.fs
@@ -34,20 +34,11 @@ module OxalcCompiler
                 Bind(fd_id, fd_t, fd_body, injectFields t p)
             | _ -> p
 
-        let rec injectTypedefs type_def p = 
-            match type_def with 
-            | TypeDefinition (name, def, cont) ->
-                TypeDefinition(name, def, match cont with 
-                    | Value(Record(fields)) -> injectFields fields p
-                    | TypeDefinition _ as type_def ->  injectTypedefs type_def p
-                )
-            | _ -> p
-
         match backend, Result with 
         | LCR, Ok (program,r)-> 
             let toSyntaxTree =  Interpreter.parse     >> (function Ok (LCRR(code),_)   -> code) >> 
                                 Interpreter.interpret >> (function Ok (program)  -> program)
-            let rec emitLambda= function
+            let rec emitLambda ctx = function
                 | Context(files, program) ->
                     let program = 
                         match files with
@@ -84,10 +75,10 @@ module OxalcCompiler
                     | Ok program -> 
                         let typeResult = TypeOf program TypingContext.Empty
                         match typeResult with
-                        | Ok(expr_type) -> 
+                        | Ok(expr_type), ctx -> 
                             printf "val it : %s = " (expr_type.ToString())
-                            emitLambda program
-                        | Error msg -> failwith msg
+                            emitLambda (Some ctx) program 
+                        | Error msg, _ -> failwith msg
                     | Error msgs -> 
                         let rec msgAcc msgs = 
                             match msgs with
@@ -96,59 +87,61 @@ module OxalcCompiler
                                 sprintf "%s: %s \n%s" label msg (msgAcc errs)
                         failwith (msgAcc msgs)
                 | Bind(name,_,  expr, value) ->
-                    Applicative(Lambda(emitLambda name, emitLambda value), emitLambda expr)
+                    match expr with 
+                    | Value(TypeDefinition(type_instance)) -> emitLambda ctx value
+                    | _ -> Applicative(Lambda(emitLambda ctx name, emitLambda ctx value), emitLambda ctx expr)
                 | Compound(expr, binds) as e -> 
-                    let rec emitBinds binds = 
+                    let rec emitBinds ctx binds = 
                         match binds with 
-                        | [] -> emitLambda expr
+                        | [] -> emitLambda ctx expr
                         | ((var, _), value) ::binds ->
-                            Applicative(Lambda(emitLambda var, emitBinds binds), emitLambda value)
-                    emitBinds binds
+                            Applicative(Lambda(emitLambda ctx var, emitBinds ctx binds), emitLambda ctx value)
+                    emitBinds ctx binds
                 | Function _ as f->
                     let emitFunction (Function([param], body)) = match param with 
-                        | (n, t)    -> Lambda(emitLambda n, emitLambda body)
+                        | (n, t)    -> Lambda(emitLambda ctx n, emitLambda ctx body)
                     f |> curry |> emitFunction
                 | Application(expr, args) as a ->
-                    let operation = emitLambda expr
+                    let operation = emitLambda ctx expr
                     let rec wrap op = function
                         | [] -> op
-                        | h::t -> wrap (Applicative(op, (emitLambda h))) t
+                        | h::t -> wrap (Applicative(op, (emitLambda ctx h))) t
                     wrap operation args
                 | Identifier(name) -> Term name
                 | Unary(Op, rhs) -> 
                     match Op with 
-                    | Not -> Applicative(Applicative(emitLambda rhs, emitLambda (Value (Bool false))), emitLambda (Value (Bool true)))
+                    | Not -> Applicative(Applicative(emitLambda ctx rhs, emitLambda ctx (Value (Bool false))), emitLambda ctx (Value (Bool true)))
                     | YComb ->
                         let Y = "\\_g.(\\_y.(_g (_y _y)) \\_y.(_g (_y _y)))" |> toSyntaxTree
-                        Applicative(Y, (emitLambda rhs))
+                        Applicative(Y, (emitLambda ctx rhs))
                     | _ -> failwith "Unary operator not supported" 
                 | Branch(cond,tClause, fClause) as (t: Statement) -> 
-                    Applicative (Applicative(emitLambda cond, emitLambda tClause), emitLambda fClause)
+                    Applicative (Applicative(emitLambda ctx cond, emitLambda ctx tClause), emitLambda ctx fClause)
                 | Binary(lhs, op, rhs) ->
-                    let isZero arg = Applicative(Applicative(arg,Lambda(Term "_w", emitLambda (Value (Bool false)))), emitLambda (Value (Bool true)))
+                    let isZero arg = Applicative(Applicative(arg,Lambda(Term "_w", emitLambda ctx (Value (Bool false)))), emitLambda ctx (Value (Bool true)))
                     let predec = "\\_n.\\_f.\\_x.(((_n \\_g.\\_h.(_h (_g _f))) \\_u._x) \\_u._u)" |> toSyntaxTree
                     match op  with 
-                    | Add -> Lambda(Term "_g", Lambda(Term "_v", Applicative(Applicative(emitLambda lhs, Term "_g"), Applicative(Applicative(emitLambda rhs, Term "_g"), Term "_v"))))
-                    | Mult-> Lambda(Term "_g", Lambda(Term "_v", Applicative(Applicative(emitLambda lhs, Applicative(emitLambda rhs, Term "_g")), Term "_v")))
-                    | Exp -> Applicative(emitLambda rhs, emitLambda lhs)
-                    | And -> Applicative(Applicative(emitLambda rhs, emitLambda lhs), emitLambda (Value (Bool false)))
-                    | Or  -> Applicative(Applicative(emitLambda rhs, emitLambda (Value (Bool false))), emitLambda lhs)
-                    | Subs-> Applicative(Applicative(emitLambda rhs, predec), emitLambda lhs)
-                    | Lt  -> isZero (emitLambda (Binary(lhs, Subs, rhs))) | Gt  -> emitLambda (Binary(rhs, Lt, lhs))
-                    | Eq  -> emitLambda (Binary(Binary(lhs, Lt, rhs), And, Binary(lhs, Gt, rhs)))
-                    | Xor -> Applicative(Applicative(emitLambda rhs, emitLambda (Unary(Not, lhs))), emitLambda lhs)
-                    | Custom(token) -> emitLambda(Application(Identifier token, [lhs; rhs]))
-                    | Cons -> emitLambda (Value (List [lhs; rhs]))
+                    | Add -> Lambda(Term "_g", Lambda(Term "_v", Applicative(Applicative(emitLambda ctx lhs, Term "_g"), Applicative(Applicative(emitLambda ctx rhs, Term "_g"), Term "_v"))))
+                    | Mult-> Lambda(Term "_g", Lambda(Term "_v", Applicative(Applicative(emitLambda ctx lhs, Applicative(emitLambda ctx rhs, Term "_g")), Term "_v")))
+                    | Exp -> Applicative(emitLambda ctx rhs, emitLambda ctx lhs)
+                    | And -> Applicative(Applicative(emitLambda ctx rhs, emitLambda ctx lhs), emitLambda ctx (Value (Bool false)))
+                    | Or  -> Applicative(Applicative(emitLambda ctx rhs, emitLambda ctx (Value (Bool false))), emitLambda ctx lhs)
+                    | Subs-> Applicative(Applicative(emitLambda ctx rhs, predec), emitLambda ctx lhs)
+                    | Lt  -> isZero (emitLambda ctx (Binary(lhs, Subs, rhs))) | Gt  -> emitLambda ctx (Binary(rhs, Lt, lhs))
+                    | Eq  -> emitLambda ctx (Binary(Binary(lhs, Lt, rhs), And, Binary(lhs, Gt, rhs)))
+                    | Xor -> Applicative(Applicative(emitLambda ctx rhs, emitLambda ctx (Unary(Not, lhs))), emitLambda ctx lhs)
+                    | Custom(token) -> emitLambda ctx (Application(Identifier token, [lhs; rhs]))
+                    | Cons -> emitLambda ctx (Value (List [lhs; rhs]))
                     | Div | Not | YComb -> failwith "Not Implemented"
                 | Value(var) -> 
                     match var with 
-                    | List(elems)-> 
+                    | List(elems) -> 
                         let cons = Lambda(Term "_h", Lambda(Term "_t", Lambda(Term "_s", Applicative(Applicative(Term "_s", Term "_h"), Term "_t"))))
-                        let empty= Lambda(Term "_l", Applicative(Term "_l", Lambda(Term "_h", Lambda(Term "_t", emitLambda(Value (Bool false))))))
-                        let nil  = Lambda(Term "_l", Applicative(Term "_l", emitLambda(Value (Bool true))))
+                        let empty= Lambda(Term "_l", Applicative(Term "_l", Lambda(Term "_h", Lambda(Term "_t", emitLambda ctx (Value (Bool false))))))
+                        let nil  = Lambda(Term "_l", Applicative(Term "_l", emitLambda ctx (Value (Bool true))))
                         let rec emitList = function 
                             | []   -> nil
-                            | h::t -> Applicative(Applicative(cons, emitLambda h), emitList t)
+                            | h::t -> Applicative(Applicative(cons, emitLambda ctx h), emitList t)
                         emitList elems
                     | Bool booleanExpr -> 
                         if booleanExpr = true 
@@ -162,11 +155,10 @@ module OxalcCompiler
                             | _ -> Applicative(Term funcn, (loop (n - 1)))
                         Lambda(Term funcn, Lambda(Term varn, loop var))
                     | _ as v -> failwithf "%A is not supported by Lambda-Calculus" v 
-                | TypeDefinition(_, _, cont) -> emitLambda cont
                 | _  -> failwith "Not Implemented or Not Compilable"
-            Ok (LCRR(emitLambda program), ``initial State``)
+            Ok (LCRR(emitLambda None program), ``initial State``)
         | JS, Ok (program,r) -> 
-            let rec emitJavascript= function
+            let rec emitJavascript ctx = function
                 | Context(files, program) ->
                     let program = 
                         match files with
@@ -185,23 +177,13 @@ module OxalcCompiler
                             let rec wrapFiles filesAst program = 
                                 match filesAst with 
                                 | []   -> Ok program
-                                | Bind(_, _ , Context(dependencies, content), _)::t ->
-                                    let dependenciesContent = all (filesContents dependencies)
-                                    match dependenciesContent with
+                                | Bind(_, _ , Context(dependencies, Value(Record(fields))), _)::t ->
+                                    match all (filesContents dependencies) with
                                     | Ok ds -> 
-                                        match content with 
-                                        | Value(Record(fields)) -> 
-                                            match wrapFiles ds (injectFields fields program) with
-                                            | Ok result -> wrapFiles t result
-                                            | Error err -> Error err
-                                        | TypeDefinition(name, def, cont) as type_def -> 
-                                            match wrapFiles ds (injectTypedefs type_def program) with
-                                            | Ok result -> wrapFiles t result
-                                            | Error err -> Error err
+                                        match wrapFiles ds (injectFields fields program) with
+                                        | Ok result -> wrapFiles t result
+                                        | Error err -> Error err
                                     | Error msg -> Error msg
-                                
-                                | Bind(_, _ , TypeDefinition(name, def, cont), _) as bind::t ->
-                                    wrapFiles t (injectTypedefs (TypeDefinition (name, def, cont)) program)
                                 | Bind(_, _ , Value(Record(fields)), _)::t ->
                                     wrapFiles t (injectFields fields program)
                                 | _ -> Error [("Import Error","Invalid file structure", None)]
@@ -212,10 +194,11 @@ module OxalcCompiler
                     | Ok program -> 
                         let typeResult = TypeOf program TypingContext.Empty
                         match typeResult with
-                        | Ok typeName -> 
+                        | Ok typeName, ctx -> 
+                            printfn "%A" ctx
                             printf "var it = " 
-                            emitJavascript program
-                        | Error msg -> failwith msg
+                            emitJavascript (Some ctx) program 
+                        | Error msg, _ -> failwith msg
                     | Error msgs -> 
                         let rec msgAcc msgs = 
                             match msgs with
@@ -224,33 +207,36 @@ module OxalcCompiler
                                 sprintf "%s: %s \n%s" label msg (msgAcc errs)
                         failwith (msgAcc msgs)
                 | Bind(name,_,  expr, value) ->
-                    if name = value then 
-                        sprintf "%s" (emitJavascript expr)
-                    else 
-                        sprintf "((%s) => %s)(%s)" (emitJavascript name) (emitJavascript value) (emitJavascript expr)
+                    match expr with 
+                    | Value(TypeDefinition(type_instance)) -> emitJavascript ctx value
+                    | _ -> 
+                        if name = value then 
+                            sprintf "%s" (emitJavascript ctx expr)
+                        else 
+                            sprintf "((%s) => %s)(%s)" (emitJavascript ctx name) (emitJavascript ctx value) (emitJavascript ctx expr)
                 | Compound(expr, binds) as e -> 
                     let rec hoistBinds binds =
                         match binds with 
                         | [((name, t), body)] -> Bind(name, t, body, expr)
                         | ((name, typ), body)::t -> Bind(name, typ, body, hoistBinds t)
-                    sprintf "%s" (emitJavascript <| hoistBinds binds) 
+                    sprintf "%s" (emitJavascript ctx <| hoistBinds binds) 
                 | Function _ as f->
                     match curry f with
                     | Function([(arg, _)], body) -> 
-                        sprintf "(%s) => %s" (emitJavascript arg) (emitJavascript body) 
+                        sprintf "(%s) => %s" (emitJavascript ctx arg) (emitJavascript ctx body) 
                 | Application(expr, args) as a ->
                     let isIdentity = 
                         match expr with 
                         | Function([(iden, _)], body) -> iden = body
                         | _ -> false
                     if isIdentity then 
-                        sprintf "%s" (emitJavascript (List.head args))
+                        sprintf "%s" (emitJavascript ctx (List.head args))
                     else
-                        let rec prepareArgs params = 
+                        let rec prepareArgs ctx params = 
                             params 
-                            |> List.map (fun p -> sprintf "(%s)" (emitJavascript p))
+                            |> List.map (fun p -> sprintf "(%s)" (emitJavascript ctx p))
                             |> List.fold (fun acc p -> sprintf "%s %s" acc p) ""
-                        sprintf "%s%s" (emitJavascript expr) (prepareArgs args)
+                        sprintf "%s%s" (emitJavascript ctx expr) (prepareArgs ctx args)
                 | Identifier(name) ->
                     let replaceSpecialCharacters c = 
                         match c with 
@@ -283,9 +269,9 @@ module OxalcCompiler
                         | Not -> "!"
                         | Subs -> "-"
                         | _ -> failwith "Not Implemented" 
-                    sprintf "%s%s" (opToString Op) (emitJavascript rhs) 
+                    sprintf "%s%s" (opToString Op) (emitJavascript ctx rhs) 
                 | Branch(cond,tClause, fClause) as (t: Statement) -> 
-                    sprintf "((%s) ? (() => %s) : (() => %s))()" (emitJavascript cond) (emitJavascript tClause) (emitJavascript fClause)
+                    sprintf "((%s) ? (() => %s) : (() => %s))()" (emitJavascript ctx cond) (emitJavascript ctx tClause) (emitJavascript ctx fClause)
                 | Binary(lhs, Op, rhs) ->
                     let isFieldLens = 
                         match rhs with 
@@ -306,27 +292,26 @@ module OxalcCompiler
                         | Or   -> "||"
                         | _ -> String.Empty
                     match Op with
-                    | Dot when isFieldLens -> sprintf "%s.%s" (emitJavascript lhs) (emitJavascript rhs)
-                    | Dot -> sprintf "%s[%s]" (emitJavascript lhs) (emitJavascript rhs)
-                    | Custom op -> sprintf "%s(%s)(%s)" (emitJavascript(Identifier op)) (emitJavascript lhs) (emitJavascript rhs)
-                    | _ -> sprintf "%s %s %s" (emitJavascript lhs) (opToString Op) (emitJavascript rhs)
+                    | Dot when isFieldLens -> sprintf "%s.%s" (emitJavascript ctx lhs) (emitJavascript ctx rhs)
+                    | Dot -> sprintf "%s[%s]" (emitJavascript ctx lhs) (emitJavascript ctx rhs)
+                    | Custom op -> sprintf "%s(%s)(%s)" (emitJavascript ctx (Identifier op)) (emitJavascript ctx lhs) (emitJavascript ctx rhs)
+                    | _ -> sprintf "%s %s %s" (emitJavascript ctx lhs) (opToString Op) (emitJavascript ctx rhs)
                 | Value(var) -> 
                     let varToString = match var with 
                         | Variable(n) -> n.ToString()
                         | Bool(b) -> b.ToString().ToLower()
                         | String(str) -> sprintf "\"%s\"" (toString str)
                         | Tuple(values) | List(values) -> 
-                            sprintf "[%s]" (String.concat "," (List.map emitJavascript values))
+                            sprintf "[%s]" (String.concat "," (List.map (emitJavascript ctx) values))
                         | Record(fields) -> 
                             let rec fieldsToString fields = 
                                 match fields with 
                                 | [] -> System.String.Empty
-                                | ((name, _, value)::t) -> sprintf "\t%s: %s,\n%s" (emitJavascript name) (emitJavascript value) (fieldsToString t)
+                                | ((name, _, value)::t) -> sprintf "\t%s: %s,\n%s" (emitJavascript ctx name) (emitJavascript ctx value) (fieldsToString t)
                             sprintf "{\n%s}" (fieldsToString fields)
                     sprintf "%s" varToString
-                | TypeDefinition(_, _, cont) -> emitJavascript cont
                 | _  -> failwith "Not Implemented or Not Compilable"
-            Ok (JSR(emitJavascript program), ``initial State``)
+            Ok (JSR(emitJavascript None program), ``initial State``)
         | target, Ok _ -> Error("Backend not supported", sprintf "%A is not supported" target, None)
         | _, Error err-> Error err
 

--- a/OxAlc.Service/Definitions.fs
+++ b/OxAlc.Service/Definitions.fs
@@ -45,7 +45,6 @@ module Typedefinitions
         (* Derivative Constructs*)
         | Identifier        of string 
         | Bind              of Statement * Type * Statement * Statement 
-        | TypeDefinition    of Statement * Type * Statement
         | Unary             of Operation * Statement
         | Binary            of Statement * Operation * Statement
         | Branch            of Statement * Statement * Statement
@@ -58,6 +57,7 @@ module Typedefinitions
         | List of List<Statement>  
         | Record of (Statement * Type * Statement) list
         | Tuple of List<Statement>
+        | TypeDefinition of Type 
     and Operation   =   Cons | Add | Subs | Div | Mult | Exp | Or | And | Eq | Neq | Lt | Not | Xor | Gt | YComb | Dot | Custom of string
                         static member toOp tokens =
                             match tokens with 


### PR DESCRIPTION
change type declaration syntax from using special "type" keyword to align with function/value declaration using "let" 